### PR TITLE
Fix tokens in non Chromium browsers

### DIFF
--- a/core/src/provide-design-system.ts
+++ b/core/src/provide-design-system.ts
@@ -3,7 +3,7 @@ import { provideTokens } from './provide-tokens';
 
 export const provideDesignSystem = (childElement?: HTMLElement): Pick<DesignSystem, 'register'> => {
   provideTokens(childElement);
-  const ds = DesignSystem.getOrCreate(childElement).withPrefix('fs');
+  const ds = DesignSystem.getOrCreate(childElement).withPrefix('fs').withDesignTokenRoot(document.documentElement);
   return new Proxy(ds, {
     get: (target, prop, ...rest) => {
       if (['withPrefix', 'withShadowRootMode', 'withElementDisambiguation'].includes(prop as string)) {


### PR DESCRIPTION
https://backlight.dev/edit/xS11aQmjMLIvr5PU5Mru/color-tokens/src/color-tokens.ts?branch=https://github.com/divriots/starter-furious/tree/fix/tokens-in-non-chromium-browsers

This is as workaround which I found to fix tokens in Firefox and Safari. It's probably related to this change https://github.com/microsoft/fast/pull/5284, but it's unclear why it doesn't work without an explicit `document.documentElement` setting, because this is how it should work by default.