### PR TITLE
feat(stories): add playground configuration and story for S2D

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -24,7 +24,7 @@
 
 # Docs and stories
 
-All components docs & stories are generated from [FAST repository](https://github.com/microsoft/fast), with the following license:
+All components docs & stories are generated from [FAST repository](https://github.com/microsoft/fast) and [Fluent UI Web repository](https://github.com/microsoft/fluentui), with the following license:
 
     MIT License
 

--- a/accordion/stories/accordion.stories.js
+++ b/accordion/stories/accordion.stories.js
@@ -3,6 +3,43 @@ import { provideDesignSystem, getAccordion, getAccordionItem, getButton, getChec
 
 provideDesignSystem().register(getAccordion(), getAccordionItem(), getButton(), getCheckbox());
 
+export default {
+  title: 'Components/Accordion',
+  argTypes: {
+    expandMode: {
+      options: ['single', 'multi'],
+      control: {
+        type: 'radio',
+      },
+      defaultValue: 'multi',
+    },
+  },
+  render: ({ expandMode }) => `
+  <fs-accordion
+    ${expandMode ? `expand-mode="${expandMode}"` : ''}
+  >
+    <fs-accordion-item expanded>
+      <div slot="start">
+        <button>1</button>
+      </div>
+      <div slot="end">
+        <button>1</button>
+      </div>
+      <span slot="heading">Panel one</span>
+      Panel one content
+    </fs-accordion-item>
+    <fs-accordion-item>
+      <span slot="heading">Panel two</span>
+      Panel two content
+    </fs-accordion-item>
+    <fs-accordion-item expanded>
+      <span slot="heading">Panel three</span>
+      Panel three content
+    </fs-accordion-item>
+  </fs-accordion>
+`,
+};
+
 export const defaultStory = () => html`
   <fs-accordion>
     <fs-accordion-item>
@@ -100,3 +137,8 @@ export const singleSelectionStory = () => html`
   </fs-accordion>
 `;
 singleSelectionStory.storyName = 'Single selection';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {},
+};

--- a/anchor/stories/anchor.stories.js
+++ b/anchor/stories/anchor.stories.js
@@ -3,6 +3,26 @@ import { provideDesignSystem, getAnchor } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getAnchor());
 
+export default {
+  title: 'Components/Anchor',
+  argTypes: {
+    appearance: {
+      options: ['neutral', 'accent', 'hypertext', 'lightweight', 'outline', 'stealth'],
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+  render: ({ appearance, label }) => `
+  <fs-anchor
+    href="javascript:void"
+    ${appearance ? `appearance="${appearance}"` : ''}
+    >
+    ${label}
+  </fs-anchor>
+`,
+};
+
 export const defaultStory = () => html` <fs-anchor href="#">Anchor</fs-anchor> `;
 defaultStory.storyName = 'Default';
 
@@ -65,3 +85,11 @@ export const iconInDefaultSlotStory = () => html`
   </fs-anchor>
 `;
 iconInDefaultSlotStory.storyName = 'Icon in default slot';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    label: 'Anchor',
+    appearance: 'neutral',
+  },
+};

--- a/badge/stories/badge.stories.js
+++ b/badge/stories/badge.stories.js
@@ -3,6 +3,22 @@ import { provideDesignSystem, getBadge } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getBadge());
 
+export default {
+  title: 'Components/Badge',
+  argTypes: {
+    appearance: {
+      options: ['neutral', 'accent', 'lightweight'],
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+  render: ({ appearance, label }) => `
+  <fs-badge
+    ${appearance ? `appearance="${appearance}"` : ''}
+  >${label}</fs-badge>`,
+};
+
 export const defaultStory = () => html`
   <div>
     <style>
@@ -20,3 +36,11 @@ export const defaultStory = () => html`
   </div>
 `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    label: 'Badge',
+    appearance: 'accent',
+  },
+};

--- a/breadcrumb/stories/breadcrumb.stories.js
+++ b/breadcrumb/stories/breadcrumb.stories.js
@@ -3,6 +3,10 @@ import { provideDesignSystem, getBreadcrumb, getBreadcrumbItem, getButton } from
 
 provideDesignSystem().register(getBreadcrumb(), getBreadcrumbItem(), getButton());
 
+export default {
+  title: 'Components/Breadcrumb',
+};
+
 export const defaultStory = () => html`
   <fs-breadcrumb>
     <fs-breadcrumb-item href="#">Breadcrumb item 1</fs-breadcrumb-item>

--- a/button/stories/button.stories.js
+++ b/button/stories/button.stories.js
@@ -3,6 +3,33 @@ import { provideDesignSystem, getButton } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getButton());
 
+export default {
+  title: 'Components/Button',
+  argTypes: {
+    appearance: {
+      description: 'This controls the basic appearances',
+      control: {
+        type: 'select',
+      },
+      options: ['neutral', 'accent', 'lightweight', 'outline', 'stealth'],
+      default: 'neutral',
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ appearance, disabled, label }) => `
+    <fs-button
+      ${disabled ? 'disabled' : ''}
+      ${appearance ? `appearance="${appearance}"` : ''}
+    >
+      ${label}
+    </fs-button>
+  `,
+};
+
 export const defaultStory = () => html` <fs-button href="#">Button</fs-button> `;
 defaultStory.storyName = 'Default';
 
@@ -65,3 +92,12 @@ export const iconInDefaultSlotStory = () => html`
   </fs-button>
 `;
 iconInDefaultSlotStory.storyName = 'Icon in default slot';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    label: 'Button',
+    disabled: false,
+    appearance: 'accent',
+  },
+};

--- a/card/stories/card.stories.js
+++ b/card/stories/card.stories.js
@@ -3,6 +3,10 @@ import { provideDesignSystem, getButton, getCard } from '@divriots/starter-furio
 
 provideDesignSystem().register(getButton(), getCard());
 
+export default {
+  title: 'Components/Card',
+};
+
 export const defaultStory = () => html`
   <fs-card style="width: 300px;">
     <img src="https://via.placeholder.com/300x200/414141" />

--- a/checkbox/stories/checkbox.stories.js
+++ b/checkbox/stories/checkbox.stories.js
@@ -3,5 +3,46 @@ import { provideDesignSystem, getCheckbox } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getCheckbox());
 
+export default {
+  title: 'Components/Checkbox',
+  argTypes: {
+    checked: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    required: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  parameters: {
+    actions: {
+      handles: ['mouseover', 'click'],
+    },
+  },
+  render: ({ checked, disabled, label, required }) => `<fs-checkbox
+    ${checked ? 'checked' : ''}
+    ${disabled ? 'disabled' : ''}
+    ${required ? 'required' : ''}
+    >${label}</fs-checkbox>`,
+};
+
 export const defaultStory = () => html` <fs-checkbox>Checkbox</fs-checkbox> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    label: 'Label string',
+    checked: false,
+    disabled: false,
+    required: false,
+  },
+};

--- a/combobox/stories/combobox.stories.js
+++ b/combobox/stories/combobox.stories.js
@@ -3,6 +3,58 @@ import { provideDesignSystem, getCombobox, getOption } from '@divriots/starter-f
 
 provideDesignSystem().register(getCombobox(), getOption());
 
+export default {
+  title: 'Components/Combobox',
+  argTypes: {
+    appearance: {
+      options: ['filled', 'outline'],
+      control: {
+        type: 'radio',
+      },
+    },
+    autocomplete: {
+      options: ['inline', 'list', 'none', 'both'],
+      control: {
+        type: 'radio',
+      },
+    },
+    position: {
+      options: ['above', 'below'],
+      control: {
+        type: 'radio',
+      },
+    },
+    required: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ appearance, autocomplete, position, required }) => `
+  <fs-combobox
+    ${appearance ? `appearance="${appearance}"` : ''}
+    ${appearance ? `autocomplete="${autocomplete}"` : ''}
+    ${required ? 'required' : ''}
+    ${position ? `position="${position}"` : ''}
+    style="margin-bottom: 500px;"
+  >
+    <fs-option>Please Please Me</fs-option>
+    <fs-option>With The Beatles</fs-option>
+    <fs-option>A Hard Day's Night</fs-option>
+    <fs-option>Beatles for Sale</fs-option>
+    <fs-option>Help!</fs-option>
+    <fs-option>Rubber Soul</fs-option>
+    <fs-option>Revolver</fs-option>
+    <fs-option>Sgt. Pepper's Lonely Hearts Club Band</fs-option>
+    <fs-option>Magical Mystery Tour</fs-option>
+    <fs-option>The Beatles</fs-option>
+    <fs-option>Yellow Submarine</fs-option>
+    <fs-option>Abbey Road</fs-option>
+    <fs-option>Let It Be</fs-option>
+  </fs-combobox>
+`,
+};
+
 export const defaultStory = () => html`
   <fs-combobox>
     <fs-option value="1">Option 1</fs-option>
@@ -11,3 +63,11 @@ export const defaultStory = () => html`
   </fs-combobox>
 `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    value: 'Christopher Eccleston',
+    appearance: 'outline',
+  },
+};

--- a/dialog/stories/dialog.stories.js
+++ b/dialog/stories/dialog.stories.js
@@ -3,6 +3,10 @@ import { provideDesignSystem, getButton, getDialog } from '@divriots/starter-fur
 
 provideDesignSystem().register(getButton(), getDialog());
 
+export default {
+  title: 'Components/Dialog',
+};
+
 export const defaultStory = () => html`
   <fs-dialog>
     <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest);">

--- a/divider/stories/divider.stories.js
+++ b/divider/stories/divider.stories.js
@@ -3,5 +3,15 @@ import { provideDesignSystem, getDivider } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getDivider());
 
+export default {
+  title: 'Components/Divider',
+  render: () => `<fs-divider role="presentation"></fs-divider>`,
+};
+
 export const defaultStory = () => html` <fs-divider></fs-divider> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {},
+};

--- a/flipper/stories/flipper.stories.js
+++ b/flipper/stories/flipper.stories.js
@@ -3,6 +3,25 @@ import { provideDesignSystem, getFlipper } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getFlipper());
 
+export default {
+  title: 'Components/Flipper',
+  argTypes: {
+    direction: {
+      options: ['previous', 'next'],
+      control: {
+        type: 'select',
+      },
+    },
+    disabled: {
+      type: 'boolean',
+    },
+  },
+  render: ({ direction, disabled, content }) => `<fs-flipper 
+    ${disabled ? 'disabled' : ''} 
+    ${direction ? `direction="${direction}"` : ''}
+  ></fs-flipper>`,
+};
+
 export const defaultStory = () => html` <fs-flipper></fs-flipper> `;
 defaultStory.storyName = 'Default';
 
@@ -30,3 +49,11 @@ export const previousWithSlottedContentStory = () => html`
   </fs-flipper>
 `;
 previousWithSlottedContentStory.storyName = 'Previous with slotted content';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    disabled: false,
+    direction: 'next',
+  },
+};

--- a/listbox/stories/listbox.stories.js
+++ b/listbox/stories/listbox.stories.js
@@ -3,6 +3,10 @@ import { provideDesignSystem, getListbox, getOption } from '@divriots/starter-fu
 
 provideDesignSystem().register(getListbox(), getOption());
 
+export default {
+  title: 'Components/Listbox',
+};
+
 export const defaultStory = () => html`
   <fs-listbox>
     <fs-option value="1">Option 1</fs-option>

--- a/menu/stories/menu.stories.js
+++ b/menu/stories/menu.stories.js
@@ -3,6 +3,28 @@ import { provideDesignSystem, getDivider, getMenu, getMenuItem } from '@divriots
 
 provideDesignSystem().register(getDivider(), getMenu(), getMenuItem());
 
+export default {
+  title: 'Components/Menu',
+  render: () => `
+  <fs-menu>
+    <fs-menu-item>Menu item 1</fs-menu-item>
+    <fs-menu-item>
+      Menu item 2
+      <fs-menu>
+        <fs-menu-item>Nested Menu item 2.1</fs-menu-item>
+        <fs-menu-item>Nested Menu item 2.2</fs-menu-item>
+        <fs-menu-item>Nested Menu item 2.3</fs-menu-item>
+      </fs-menu>
+    </fs-menu-item>
+    <fs-menu-item disabled="true">Menu item 3</fs-menu-item>
+    <fs-menu-item>
+      Menu item 4
+      <div slot="end">Shortcut text</div>
+    </fs-menu-item>
+  </fs-menu>
+`,
+};
+
 export const defaultStory = () => html`
   <fs-menu>
     <fs-menu-item>Menu item 1</fs-menu-item>
@@ -111,3 +133,8 @@ export const withIconsStory = () => html`
   </fs-menu>
 `;
 withIconsStory.storyName = 'With icons';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {},
+};

--- a/number-field/stories/number-field.stories.js
+++ b/number-field/stories/number-field.stories.js
@@ -3,5 +3,118 @@ import { provideDesignSystem, getNumberField } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getNumberField());
 
+export default {
+  title: 'Components/Number Field',
+  argTypes: {
+    appearance: {
+      defaultValue: 'outline',
+      options: ['filled', 'outline'],
+      control: {
+        type: 'radio',
+      },
+    },
+    autoFocus: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    hideStep: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    maxlength: {
+      control: {
+        type: 'number',
+      },
+    },
+    minlength: {
+      control: {
+        type: 'number',
+      },
+    },
+    placeholder: {
+      control: {
+        type: 'text',
+      },
+    },
+    readonly: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    required: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    step: {
+      control: {
+        type: 'number',
+      },
+      defaultValue: 1,
+    },
+    size: {
+      control: {
+        type: 'number',
+      },
+    },
+    value: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  render: ({
+    appearance,
+    autoFocus,
+    disabled,
+    hideStep,
+    label,
+    maxlength,
+    minlength,
+    placeholder,
+    readonly,
+    required,
+    size,
+    step,
+    value,
+  }) => `
+  <fs-number-field
+    ${appearance ? `appearance="${appearance}"` : ''}
+    ${autoFocus ? 'autofocus' : ''}
+    ${disabled ? 'disabled' : ''}
+    ${hideStep ? 'hide-step' : ''}
+    ${maxlength ? `maxlength="${maxlength}"` : ''}
+    ${minlength ? `minlength="${minlength}"` : ''}
+    ${placeholder ? `placeholder="${placeholder}"` : ''}
+    ${readonly ? 'readonly' : ''}
+    ${required ? 'required' : ''}
+    ${size ? `size="${size}"` : ''}
+    ${step ? `step="${step}"` : ''}
+    ${value ? `value="${value}"` : ''}
+  >
+    ${label ? `${label}` : ''}
+  </fs-number-field>
+`,
+};
+
 export const defaultStory = () => html` <fs-number-field placeholder="number"></fs-number-field> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    placeholder: 'type a number',
+    autoFocus: false,
+    disabled: false,
+    hideStep: false,
+    readonly: false,
+    required: false,
+  },
+};

--- a/progress-ring/stories/progress-ring.stories.js
+++ b/progress-ring/stories/progress-ring.stories.js
@@ -3,5 +3,30 @@ import { provideDesignSystem, getProgressRing } from '@divriots/starter-furious'
 
 provideDesignSystem().register(getProgressRing());
 
+export default {
+  title: 'Components/Progress Ring',
+  argTypes: {
+    paused: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ paused, value }) => `
+  <fs-progress-ring
+    ${value ? `value="${value}"` : ''}
+    ${paused ? `paused="${paused}"` : ''}
+  ></fs-progress-ring>
+`,
+};
+
 export const defaultStory = () => html` <fs-progress-ring></fs-progress-ring> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    paused: false,
+    value: 65,
+  },
+};

--- a/progress/stories/progress.stories.js
+++ b/progress/stories/progress.stories.js
@@ -3,5 +3,30 @@ import { provideDesignSystem, getProgress } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getProgress());
 
+export default {
+  title: 'Components/Progress',
+  argTypes: {
+    paused: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ paused, value }) => `
+  <fs-progress
+    ${paused ? `paused="${paused}"` : ''}
+    ${value ? `value=${value}` : ''}
+  ></fs-progress>
+`,
+};
+
 export const defaultStory = () => html` <fs-progress></fs-progress> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    paused: false,
+    value: 50,
+  },
+};

--- a/radio-group/stories/radio-group.stories.js
+++ b/radio-group/stories/radio-group.stories.js
@@ -3,6 +3,31 @@ import { provideDesignSystem, getRadio, getRadioGroup } from '@divriots/starter-
 
 provideDesignSystem().register(getRadio(), getRadioGroup());
 
+export default {
+  title: 'Components/Radio Group',
+  argTypes: {
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    required: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ disabled, required }) => `
+  <fs-radio-group
+    ${disabled ? 'disabled' : ''}
+    ${required ? 'required' : ''}
+  >
+    <fs-radio>Apples</fs-radio>
+    <fs-radio>Bananas</fs-radio>
+    <fs-radio>Tomatoes</fs-radio>
+  </fs-radio-group>`,
+};
+
 export const defaultStory = () => html`
   <fs-radio-group>
     <label style="color: var(--neutral-foreground-rest);" slot="label"> Group label </label>
@@ -12,3 +37,11 @@ export const defaultStory = () => html`
   </fs-radio-group>
 `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    disabled: false,
+    required: false,
+  },
+};

--- a/radio/stories/radio.stories.js
+++ b/radio/stories/radio.stories.js
@@ -3,5 +3,43 @@ import { provideDesignSystem, getRadio } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getRadio());
 
+export default {
+  title: 'Components/Radio',
+  argTypes: {
+    checked: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    required: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ checked, disabled, required, label }) => `
+  <fs-radio
+    ${checked ? 'checked' : ''}
+    ${disabled ? 'disabled' : ''}
+    ${required ? 'required' : ''}
+  >${label}</fs-radio>
+`,
+};
+
 export const defaultStory = () => html` <fs-radio>Label</fs-radio> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    label: 'Label',
+    checked: false,
+    disabled: false,
+    required: false,
+  },
+};

--- a/select/stories/select.stories.js
+++ b/select/stories/select.stories.js
@@ -3,6 +3,44 @@ import { provideDesignSystem, getOption, getSelect } from '@divriots/starter-fur
 
 provideDesignSystem().register(getOption(), getSelect());
 
+export default {
+  title: 'Components/Select',
+  argTypes: {
+    appearance: {
+      options: ['filled', 'outlined', 'stealth'],
+      control: {
+        type: 'radio',
+      },
+      defaultValue: 'outlined',
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    position: {
+      options: ['above', 'below'],
+      control: {
+        type: 'radio',
+      },
+      defaultValue: 'below',
+    },
+  },
+  render: ({ appearance, disabled, position }) => `
+  <fs-select
+    ${appearance ? `appearance="${appearance}"` : ''}
+    ${disabled ? 'disabled' : ''} 
+    ${position ? `position="${position}"` : ''}
+    style="margin-bottom: 200px;"
+  >
+    <fs-option>Option One</fs-option>
+    <fs-option>Option Two</fs-option>
+    <fs-option>Option Three</fs-option>
+    <fs-option>Option Four</fs-option>
+  </fs-select>
+`,
+};
+
 export const defaultStory = () => html`
   <fs-select>
     <fs-option value="1">Option 1</fs-option>
@@ -11,3 +49,10 @@ export const defaultStory = () => html`
   </fs-select>
 `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    disabled: false,
+  },
+};

--- a/skeleton/stories/skeleton.stories.js
+++ b/skeleton/stories/skeleton.stories.js
@@ -3,6 +3,31 @@ import { provideDesignSystem, getSkeleton } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getSkeleton());
 
+export default {
+  title: 'Components/Skeleton',
+  argTypes: {
+    shape: {
+      defaultValue: 'rect',
+      options: ['circle', 'rect'],
+      control: {
+        type: 'radio',
+      },
+    },
+    shimmer: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ shape, shimmer }) => `
+  <fs-skeleton 
+    ${shape ? `shape="${shape}"` : ''}
+    ${shimmer ? 'shimmer' : ''} 
+    style="margin-top: 10px; height: 50px; width: 50px"
+  ></fs-skeleton>
+`,
+};
+
 export const defaultStory = () => html`
   <div>
     <div class="card-placeholder">
@@ -45,3 +70,11 @@ export const defaultStory = () => html`
   </div>
 `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    shape: 'rect',
+    shimmer: false,
+  },
+};

--- a/slider/stories/slider.stories.js
+++ b/slider/stories/slider.stories.js
@@ -3,6 +3,28 @@ import { provideDesignSystem, getSlider, getSliderLabel } from '@divriots/starte
 
 provideDesignSystem().register(getSlider(), getSliderLabel());
 
+export default {
+  title: 'Components/Slider',
+  argTypes: {
+    orientation: {
+      options: ['horizontal', 'vertical'],
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+  render: ({ orientation }) => `
+  <fs-slider
+    ${orientation ? `orientation="${orientation}"` : ''}
+    min="0" max="100" step="10" style="width:80%;"
+  >
+    <fs-slider-label position="0"> 0&#8451; </fs-slider-label>
+    <fs-slider-label position="10"> 10&#8451; </fs-slider-label>
+    <fs-slider-label position="90"> 90&#8451; </fs-slider-label>
+    <fs-slider-label position="100"> 100&#8451; </fs-slider-label>
+  </fs-slider>`,
+};
+
 export const defaultStory = () => html` <fs-slider></fs-slider> `;
 defaultStory.storyName = 'Default';
 
@@ -25,3 +47,10 @@ export const orientationWithLabelsStory = () => html`
   </fs-slider>
 `;
 orientationWithLabelsStory.storyName = 'Orientation with labels';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    orientation: 'horizontal',
+  },
+};

--- a/switch/stories/switch.stories.js
+++ b/switch/stories/switch.stories.js
@@ -3,6 +3,31 @@ import { provideDesignSystem, getSwitch } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getSwitch());
 
+export default {
+  title: 'Components/Switch',
+  argTypes: {
+    checked: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ checked, disabled, label }) => `
+<fs-switch
+  ${checked ? 'checked' : ''}
+  ${disabled ? 'disabled' : ''}
+>${label}
+  <span slot="checked-message">On</span>
+  <span slot="unchecked-message">Off</span>
+</fs-switch>
+`,
+};
+
 export const defaultStory = () => html` <fs-switch></fs-switch> `;
 defaultStory.storyName = 'Default';
 
@@ -17,3 +42,12 @@ export const withSlotCheckedAndUncheckedMessageStory = () => html`
   </fs-switch>
 `;
 withSlotCheckedAndUncheckedMessageStory.storyName = 'With slot, checked and unchecked message';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    label: 'Label',
+    checked: false,
+    disabled: false,
+  },
+};

--- a/tabs/stories/tabs.stories.js
+++ b/tabs/stories/tabs.stories.js
@@ -3,6 +3,90 @@ import { provideDesignSystem, getButton, getTab, getTabPanel, getTabs } from '@d
 
 provideDesignSystem().register(getButton(), getTab(), getTabPanel(), getTabs());
 
+export default {
+  title: 'Components/Tabs',
+  argTypes: {
+    activeIndicator: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    orientation: {
+      options: ['horizontal', 'vertical'],
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+  render: ({ activeId, activeIndicator, orientation }) => `
+<fs-tabs
+  ${orientation ? `orientation="${orientation}"` : ''}
+  ${activeIndicator ? `activeIndicator="${activeIndicator}"` : ''}
+  ${activeId ? `activeId="${activeId}"` : ''}
+>
+  <fs-tab id="TabOne">Tab one</fs-tab>
+  <fs-tab id="TabTwo">Tab two</fs-tab>
+  <fs-tab id="TabThree">Tab three</fs-tab>
+  <fs-tab-panel>
+    Tab one content. This is for testing. Tab three content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+    Tab one content. This is for testing.
+    <br />
+  </fs-tab-panel>
+  <fs-tab-panel> Tab two content. This is for testing. </fs-tab-panel>
+  <fs-tab-panel>
+    Tab three content. This is for testing. Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+    Tab three content. This is for testing.
+    <br />
+  </fs-tab-panel>
+</fs-tabs>`,
+};
+
 export const defaultStory = () => html`
   <fs-tabs>
     <fs-tab slot="tab">Tab one</fs-tab>
@@ -40,3 +124,12 @@ export const withStartAndEndStory = () => html`
   </fs-tabs>
 `;
 withStartAndEndStory.storyName = 'With start and end';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    activeId: 'TabTwo',
+    activeIndicator: true,
+    orientation: 'horizontal',
+  },
+};

--- a/text-area/stories/text-area.stories.js
+++ b/text-area/stories/text-area.stories.js
@@ -3,5 +3,65 @@ import { provideDesignSystem, getTextArea } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getTextArea());
 
+export default {
+  title: 'Components/Text Area',
+  argTypes: {
+    appearance: {
+      defaultValue: 'outlined',
+      options: ['filled', 'outlined'],
+      control: {
+        type: 'radio',
+      },
+    },
+    autoFocus: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    readonly: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    resize: {
+      options: ['both', 'horizontal', 'vertical'],
+      control: {
+        type: 'select',
+      },
+    },
+    required: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ appearance, autoFocus, disabled, placeholder, readonly, resize, required }) => `
+<fs-text-area
+  ${appearance ? `appearance="${appearance}"` : ''}
+  ${autoFocus ? 'autofocus' : ''}
+  ${disabled ? 'disabled' : ''}
+  ${placeholder ? `placeholder="${placeholder}"` : ''}
+  ${readonly ? 'readonly' : ''}
+  ${resize ? `resize="${resize}"` : ''}
+  ${required ? 'required' : ''}
+></fs-text-area>`,
+};
+
 export const defaultStory = () => html` <fs-text-area></fs-text-area> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    placeholder: '',
+    autoFocus: false,
+    disabled: false,
+    readonly: false,
+    required: false,
+  },
+};

--- a/text-field/stories/text-field.stories.js
+++ b/text-field/stories/text-field.stories.js
@@ -3,5 +3,126 @@ import { provideDesignSystem, getTextField } from '@divriots/starter-furious';
 
 provideDesignSystem().register(getTextField());
 
+export default {
+  title: 'Components/Text Field',
+  argTypes: {
+    appearance: {
+      options: ['filled', 'outline'],
+      defaultValue: 'outline',
+      control: {
+        type: 'radio',
+      },
+    },
+    autoFocus: {
+      description: 'Automatically focuses the control',
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      description: 'The text field should be submitted with the form but should not be editable',
+      control: {
+        type: 'boolean',
+      },
+    },
+    list: {
+      control: {
+        type: 'text',
+      },
+    },
+    maxlength: {
+      control: {
+        type: 'number',
+      },
+    },
+    name: {
+      control: {
+        type: 'text',
+      },
+    },
+    minlength: {
+      control: {
+        type: 'number',
+      },
+    },
+    pattern: {
+      description: `A regular expression the input's contents must match in order to be valid`,
+      control: {
+        type: 'text',
+      },
+    },
+    placeholder: {
+      description: 'An exemplar value to display in the input field whenever it is empty',
+      defaultValue: 'Placeholder',
+      control: {
+        type: 'text',
+      },
+    },
+    readonly: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    required: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    spellcheck: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    type: {
+      options: ['text', 'email', 'password', 'tel', 'url'],
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+  render: ({
+    appearance,
+    autoFocus,
+    disabled,
+    list,
+    maxlength,
+    name,
+    minlength,
+    pattern,
+    placeholder,
+    readonly,
+    required,
+    size,
+    spellcheck,
+    type,
+  }) => `<fs-text-field
+    ${appearance ? `appearance="${appearance}"` : ''}
+    ${autoFocus ? 'autofocus' : ''}
+    ${disabled ? 'disabled' : ''}
+    ${list ? `list="${list}"` : ''}
+    ${maxlength ? `maxlength="${maxlength}"` : ''}
+    ${name ? `name="${name}"` : ''}
+    ${minlength ? `minlength="${minlength}"` : ''}
+    ${pattern ? `pattern="${pattern}"` : ''}
+    ${placeholder ? `placeholder="${placeholder}"` : ''}
+    ${readonly ? 'readonly' : ''}
+    ${required ? 'required' : ''}
+    ${spellcheck ? `spellcheck="${spellcheck}"` : ''}
+    ${size ? `size="${size}"` : ''}
+    ${type ? `type="${type}"` : ''}
+  ></fs-text-field>`,
+};
+
 export const defaultStory = () => html` <fs-text-field placeholder="name"></fs-text-field> `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    placeholder: 'placeholder',
+    autoFocus: false,
+    disabled: false,
+    readonly: false,
+    required: false,
+  },
+};

--- a/toolbar/stories/toolbar.stories.js
+++ b/toolbar/stories/toolbar.stories.js
@@ -3,6 +3,10 @@ import { provideDesignSystem, getCheckbox, getToolbar } from '@divriots/starter-
 
 provideDesignSystem().register(getCheckbox(), getToolbar());
 
+export default {
+  title: 'Components/Toolbar',
+};
+
 export const defaultStory = () => html`
   <fs-toolbar>
     <label slot="label">Toolbar</label>

--- a/tooltip/stories/tooltip.stories.js
+++ b/tooltip/stories/tooltip.stories.js
@@ -3,6 +3,27 @@ import { provideDesignSystem, getButton, getTooltip } from '@divriots/starter-fu
 
 provideDesignSystem().register(getButton(), getTooltip());
 
+export default {
+  title: 'Components/Tooltip',
+  argTypes: {
+    position: {
+      options: ['top', 'right', 'bottom', 'left'],
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+  render: ({ label, position }) => `
+  <fs-tooltip 
+    anchor="button" 
+    ${position ? `position="${position}"` : ''}
+  >
+    ${label}
+  </fs-tooltip>
+  <fs-button id="button">Reveal Tooltip</fs-button>
+`,
+};
+
 export const defaultStory = () => html`
   <div>
     <fs-button id="anchor" style="height: 40px; width: 100px; margin: 100px; background: green;"> Hover me </fs-button>
@@ -10,3 +31,10 @@ export const defaultStory = () => html`
   </div>
 `;
 defaultStory.storyName = 'Default';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    label: `I'm helping!`,
+  },
+};

--- a/tree-view/stories/tree-view.stories.js
+++ b/tree-view/stories/tree-view.stories.js
@@ -3,6 +3,63 @@ import { provideDesignSystem, getTreeItem, getTreeView } from '@divriots/starter
 
 provideDesignSystem().register(getTreeItem(), getTreeView());
 
+export default {
+  title: 'Components/Tree View',
+  argTypes: {
+    renderCollapsedNodes: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  render: ({ renderCollapsedNodes }) => `
+<fs-tree-view
+  ${renderCollapsedNodes ? `render-collapsed-nodes="${renderCollapsedNodes}` : ''}
+">
+  <fs-tree-item>
+    Root item 1
+    <fs-tree-item>
+      Root item 1
+      <fs-tree-item>
+        Flowers
+        <fs-tree-item disabled>Daisy</fs-tree-item>
+        <fs-tree-item>
+          Sunflower
+          <svg slot="start" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M12 5.5a1 1 0 100 2 1 1 0 000-2zm-5 1a1 1 0 112 0 1 1 0 01-2 0zm3.5-4a.5.5 0 00-1 0V3h-3C5.67 3 5 3.67 5 4.5v4c0 .83.67 1.5 1.5 1.5h7c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-3v-.5zM6.5 4h7c.28 0 .5.22.5.5v4a.5.5 0 01-.5.5h-7a.5.5 0 01-.5-.5v-4c0-.28.22-.5.5-.5zm3.75 14c2.62-.04 4.2-.6 5.12-1.44A3.52 3.52 0 0016.5 14h.01v-.69c0-1-.81-1.8-1.8-1.8h-3.2v-.01H5.3c-.99 0-1.8.81-1.8 1.81v.7c.04.77.25 1.75 1.13 2.55.93.84 2.5 1.4 5.12 1.44h.5zm-4.94-5.5h9.38c.45 0 .81.37.81.81v.44c0 .69-.13 1.46-.8 2.07C14 16.45 12.66 17 10 17s-4.01-.55-4.7-1.18a2.63 2.63 0 01-.8-2.07v-.44c0-.44.36-.8.8-.8z"
+            />
+          </svg>
+          <svg slot="end" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M12 5.5a1 1 0 100 2 1 1 0 000-2zm-5 1a1 1 0 112 0 1 1 0 01-2 0zm3.5-4a.5.5 0 00-1 0V3h-3C5.67 3 5 3.67 5 4.5v4c0 .83.67 1.5 1.5 1.5h7c.83 0 1.5-.67 1.5-1.5v-4c0-.83-.67-1.5-1.5-1.5h-3v-.5zM6.5 4h7c.28 0 .5.22.5.5v4a.5.5 0 01-.5.5h-7a.5.5 0 01-.5-.5v-4c0-.28.22-.5.5-.5zm3.75 14c2.62-.04 4.2-.6 5.12-1.44A3.52 3.52 0 0016.5 14h.01v-.69c0-1-.81-1.8-1.8-1.8h-3.2v-.01H5.3c-.99 0-1.8.81-1.8 1.81v.7c.04.77.25 1.75 1.13 2.55.93.84 2.5 1.4 5.12 1.44h.5zm-4.94-5.5h9.38c.45 0 .81.37.81.81v.44c0 .69-.13 1.46-.8 2.07C14 16.45 12.66 17 10 17s-4.01-.55-4.7-1.18a2.63 2.63 0 01-.8-2.07v-.44c0-.44.36-.8.8-.8z"
+            />
+          </svg>
+        </fs-tree-item>
+        <fs-tree-item>Rose</fs-tree-item>
+      </fs-tree-item>
+      <fs-tree-item>Nested item 2</fs-tree-item>
+      <fs-tree-item>Nested item 3</fs-tree-item>
+    </fs-tree-item>
+    <fs-tree-item>Nested item 2</fs-tree-item>
+    <fs-tree-item>Nested item 3</fs-tree-item>
+  </fs-tree-item>
+  <fs-tree-item>
+    Root item 2
+    <fs-divider></fs-divider>
+    <fs-tree-item>
+      Flowers
+      <fs-tree-item disabled>Daisy</fs-tree-item>
+      <fs-tree-item>Sunflower</fs-tree-item>
+      <fs-tree-item>Rose</fs-tree-item>
+    </fs-tree-item>
+    <fs-tree-item>Nested item 2</fs-tree-item>
+    <fs-tree-item>Nested item 3</fs-tree-item>
+  </fs-tree-item>
+  <fs-tree-item> Root item 3 - Leaf Erikson </fs-tree-item>
+</fs-tree-view>`,
+};
+
 export const defaultStory = () => html`
   <fs-tree-view>
     <fs-tree-item>
@@ -23,3 +80,10 @@ export const flatStory = () => html`
   </fs-tree-view>
 `;
 flatStory.storyName = 'Flat';
+
+export const playgroundStory = {
+  name: 'Playground (S2D)',
+  args: {
+    renderCollapsedNodes: false,
+  },
+};


### PR DESCRIPTION
This is for S2D to generate variants in Figma and showcase the plugin and at the same time to add designs in Furious.

Stories are auto-generated based on FluentUI monorepo stories.

Example for the button:

![image](https://user-images.githubusercontent.com/137844/169567826-2c2b4078-57e9-4d93-9d2b-98e1240d2612.png)